### PR TITLE
Change the team layout

### DIFF
--- a/content/team/a.md
+++ b/content/team/a.md
@@ -1,9 +1,9 @@
 ---
-title: "Sage Kirk"
+title: "Sage"
 date: 2018-11-19T10:47:58+10:00
 draft: false
 image: "images/team/sage-kirk-485982-unsplash.jpg"
 jobtitle: "PhD"
 linkedinurl: ""
-weight: 2
+weight: 1
 ---

--- a/content/team/sage-kirk.md
+++ b/content/team/sage-kirk.md
@@ -1,11 +1,11 @@
 ---
-title: "Sage Kirk"
+title: "Sage Lorem Kirk"
 date: 2018-11-19T10:47:58+10:00
 draft: false
 image: "images/team/sage-kirk-485982-unsplash.jpg"
 jobtitle: "Accountant"
 linkedinurl: ""
-weight: 2
+weight: 3
 ---
 
 Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Bibendum arcu vitae elementum curabitur vitae nunc sed. Tortor at risus viverra adipiscing at in.

--- a/themes/hugo-serif-theme/layouts/team/list.html
+++ b/themes/hugo-serif-theme/layouts/team/list.html
@@ -21,10 +21,31 @@
 </div>
 
 <div class="container pt-6 pb-md-6">
+  <h1> Faculty </h1>
   <div class="row">
-    {{ range .Pages.ByWeight }}
-    <div class="col-12 col-md-6 mb-2 ">{{ .Render "summary" }}</div>
+    {{ range .Pages }}
+    {{ if eq .Weight 1 }}
+    <div class="col-12 col-md-6 mb-2 ">{{ .Render "summary"}}</div>
+    {{ end }}
     {{ end }}
   </div>
+  <h1> Post Doctoral Fellow </h1>
+  <div class="row">
+    {{ range .Pages }}
+    {{ if eq .Weight 2 }}
+    <div class="col-12 col-md-6 mb-2 ">{{ .Render "summary" }}</div>
+    {{ end }}
+    {{ end }}
+  </div>
+  <h1> Undergraduate Students </h1>
+  <div class="row">
+    {{ range .Pages }}
+    {{ if eq .Weight 3 }}
+    <div class="col-12 col-md-6 mb-2 ">{{ .Render "summary" }}</div>
+    {{ end }}
+    {{ end }}
+  </div>
+
+
 </div>
 {{ end }}


### PR DESCRIPTION
I have formatted the team layout according to the following segments -
1. Faculty
2. Postdoctoral fellows
3. Undergraduate Students

This new method will work according to the following rules
1. Faculties will be assigned ` weight: 1`
2. Postdoctoral will be assigned `weight: 2`
3. Undergraduate Students will have `weight 3`

Likewise, all new entries can be sorted out in the same manner. 

![Screenshot from 2020-08-27 00-55-20](https://user-images.githubusercontent.com/33135343/91347506-19e05e00-e800-11ea-85fe-b5615e3e5b39.png)
This is the preview.